### PR TITLE
Support deleting exhibits in Spotlight

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -270,6 +270,7 @@ RSpec/PredicateMatcher:
     - 'spec/controllers/spotlight/catalog_controller_spec.rb'
     - 'spec/controllers/spotlight/exhibits_controller_spec.rb'
     - 'spec/features/feature_page_spec.rb'
+    - 'spec/features/exhibit_deletion_spec.rb'
     - 'spec/helpers/spotlight/navbar_helper_spec.rb'
     - 'spec/helpers/spotlight/pages_helper_spec.rb'
     - 'spec/lib/spotlight/controller_spec.rb'

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -75,6 +75,7 @@ module Spotlight
     end
 
     def destroy
+      @exhibit.resources.destroy_all
       @exhibit.destroy
 
       redirect_to main_app.root_url, notice: t(:'helpers.submit.exhibit.destroyed', model: @exhibit.class.model_name.human.downcase)

--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -22,6 +22,8 @@ module Spotlight
     after_index :commit
     after_index :touch_exhibit!
 
+    after_destroy :cleanup_solr
+
     ##
     # Persist the record to the database, and trigger a reindex to solr
     #
@@ -75,6 +77,14 @@ module Spotlight
 
       def connection_config
         Blacklight.connection_config
+      end
+
+      def cleanup_solr
+        blacklight_solr.delete_by_id(document_ids, params: { softCommit: true })
+      end
+
+      def document_ids
+        document_builder.documents_to_index.to_a.map { |y| y[:id] }
       end
 
       def batch_size

--- a/spec/controllers/spotlight/exhibits_controller_spec.rb
+++ b/spec/controllers/spotlight/exhibits_controller_spec.rb
@@ -205,6 +205,7 @@ describe Spotlight::ExhibitsController, type: :controller do
     describe '#destroy' do
       it 'is successful' do
         delete :destroy, params: { id: exhibit }
+
         expect(Spotlight::Exhibit.exists?(exhibit.id)).to be_falsey
         expect(flash[:notice]).to eq 'The exhibit was deleted.'
         expect(response).to redirect_to main_app.root_path

--- a/spec/features/exhibit_deletion_spec.rb
+++ b/spec/features/exhibit_deletion_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe 'Deleting an exhibit', type: :feature do
+  include ActiveJob::TestHelper
+
+  let!(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:user) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+  before { login_as user }
+
+  it 'removes items associated witht the exhibit', js: true do
+    visit spotlight.new_exhibit_resource_path(exhibit)
+    click_link 'Upload item'
+    attach_file('resources_upload_url', File.join(FIXTURES_PATH, '800x600.png'))
+    fill_in 'Title', with: '800x600'
+
+    within '#new_resources_upload' do
+      click_button 'Add item'
+    end
+    expect(page).to have_content 'Object uploaded successfully.'
+
+    visit spotlight.exhibit_dashboard_path(exhibit)
+    upload_before_delete = exhibit.resources.last.id
+    within '#sidebar' do
+      click_link 'General'
+    end
+
+    within '.nav-tabs' do
+      click_link 'Delete exhibit'
+    end
+
+    accept_confirm do
+      click_link 'Delete'
+    end
+    expect(page).to have_content('The exhibit was deleted')
+
+    expect(Spotlight::Exhibit.exists?(exhibit.id)).to be_falsey
+    expect(Spotlight::Resources::Upload.exists?(upload_before_delete)).to be_falsey
+  end
+end


### PR DESCRIPTION
Note: For now, this is very heavy handed, and likely would never be
accepted upstream because it applies to all Spotlight resources, instead
of targeting specific kinds (Uploads, for example).

Going to test this out w/ a complete staging environment here shortly. But wanted to put up something as an FYI ( cc: @dunn )